### PR TITLE
Fix Kernelspec name 'Python with Pixiedust (Spark 2.3)' is invalid

### DIFF
--- a/install/createKernel.py
+++ b/install/createKernel.py
@@ -255,7 +255,7 @@ class PixiedustInstall(InstallKernelSpec):
         if download_scala:
             self.download_scala(scala_version)
 
-        self.kernelName = "Python with Pixiedust (Spark {}.{})".format(spark_version[0], spark_version[1])
+        self.kernelName = "Python-with-Pixiedust_Spark-{}.{}".format(spark_version[0], spark_version[1])
         if silent:
             answer = 'y'
         else:


### PR DESCRIPTION
Fix WARNING | Kernelspec name 'Python with Pixiedust (Spark 2.3)' is invalid : Kernel names can only contain ASCII letters and numbers and these separators: - . _ (hyphen, period, and underscore).