### PR TITLE
#307 - default update legend option value

### DIFF
--- a/pixiedust/display/chart/renderers/commonOptions.py
+++ b/pixiedust/display/chart/renderers/commonOptions.py
@@ -137,7 +137,7 @@ def lineChart(displayObject):
         'description': 'Show legend',
         'metadata': {
             'type': 'checkbox',
-            'default': "false"
+            'default': "true"
         }
     })
 


### PR DESCRIPTION
legend option for line chart is inconsistent with other charts causing incorrect checkbox status in the UI