### PR TITLE
file download fixes

### DIFF
--- a/pixiedust/display/display.py
+++ b/pixiedust/display/display.py
@@ -26,7 +26,7 @@ import time
 import re
 import six
 import pixiedust
-from six import iteritems, with_metaclass
+from six import iteritems, with_metaclass, string_types, text_type
 from functools import reduce
 import json
 
@@ -365,10 +365,10 @@ class Display(with_metaclass(ABCMeta)):
         self._addJavascript(self.renderTemplate(templateName, **kwargs))
     
     def _safeString(self, s):
-        if not isinstance(s, str if sys.version >= '3' else basestring):
+        if not isinstance(s, string_types):
             return str(s)
         else:
-            return s.encode('ascii', 'ignore')
+            return text_type(s.encode('ascii', 'ignore'), 'ascii')
         
     #def _addD3Script2(self):
     #    print("Adding d3")

--- a/pixiedust/display/download/downloadFile.py
+++ b/pixiedust/display/download/downloadFile.py
@@ -17,6 +17,8 @@
 from ..display import Display
 from functools import reduce
 import time
+import numpy as np
+from six import integer_types
 
 DELIMITER="@#$DELIMITER@#$"
 
@@ -113,7 +115,9 @@ class DownloadFileHandler(Display):
             print("[")
             for count, row in enumerate(entity.take(doDownloadCount), start=1):
                 print(" {")
-                print(reduce(lambda s,f: s+(",\n  " if s!="" else "  ")+"\""+self._safeString(f.name)+"\":"+(str(row[f.name]) if isinstance(row[f.name],(int,long, float)) else self._safeString("\""+("" if row[f.name] is None else row[f.name])+"\"")), schema.fields, ""))
+                # numeric types: python2 (int, long, float, complex), python3 (int, float, complex)
+                # in some builds `np.intXX` does not descend from `int`: https://stackoverflow.com/a/48467599
+                print(reduce(lambda s,f: s+(",\n  " if s!="" else "  ")+"\""+self._safeString(f.name)+"\":"+(str(row[f.name]) if isinstance(row[f.name], integer_types + (float, np.number)) else self._safeString("\""+("" if row[f.name] is None else row[f.name])+"\"")), schema.fields, ""))
                 print(" }," if count != doDownloadCount else " }")
             print("]")
             print(DELIMITER)

--- a/pixiedust/utils/dataFrameAdapter.py
+++ b/pixiedust/utils/dataFrameAdapter.py
@@ -78,6 +78,13 @@ class PandasDataFrameAdapter(object):
         else:
             return len(self.entity.index)
 
+    def show(self,num):
+        if self.sparkDF:
+            return self.entity.show(num)
+        else:
+            dfshow = self.entity.head(num)
+            return dfshow.to_string()
+
     def take(self,num):
         if self.sparkDF:
             return self.entity.take(num)


### PR DESCRIPTION
@DTAIEB 
fixed issue causing file download to fail for all options in python 3.x
- `TypeError: Can't convert 'bytes' object to str implicitly`
  - strings are handled differently (`byte`, `unicode`) between python 2.x, 3.x

fixed issue causing file download to fail for JSON option in python 3.x
- `NameError: name 'long' is not defined`
  - `long` is a numeric type in python 2.x but no longer in python 3.x

fixed issue causing file download to fail for Plain Text option with Pandas dataframe
- `AttributeError: show attribute not found`
  - `PandasDataFrameAdapter` code did not have an implementation of `show` method

FYI, none of these errors surfaced in the notebook cell. The `display` output cell was just blank. To see the actual error and stack trace you have to copy the full `display` command from the browser console and run it in a new cell.