### PR TITLE
checks for variables and install packages on the basis of defined va…

### DIFF
--- a/pixiedust/packageManager/packageManager.py
+++ b/pixiedust/packageManager/packageManager.py
@@ -46,11 +46,11 @@ packageStorage = __PackageStorage()
 
 class PackageManager(object):
     if "PIXIEDUST_HOME" in os.environ:
-        DOWNLOAD_DIR=os.environ.get("PIXIEDUST_HOME") + "/data/libs"
+        DOWNLOAD_DIR=os.environ.get('PIXIEDUST_HOME') + "/data/libs"
     elif "PIXIEDUST_LIBS_PATH" in os.environ:
-        DOWNLOAD_DIR=os.environ.get("PIXIEDUST_LIBS_PATH")
+        DOWNLOAD_DIR=os.environ.get('PIXIEDUST_LIBS_PATH')
     else:
-        DOWNLOAD_DIR=os.environ.get("HOME") + "/data/libs"
+        DOWNLOAD_DIR=os.environ.get('HOME') + "/data/libs"
 
 
     # Issue 492: https://github.com/ibm-watson-data-lab/pixiedust/issues/492

--- a/pixiedust/packageManager/packageManager.py
+++ b/pixiedust/packageManager/packageManager.py
@@ -45,7 +45,13 @@ class __PackageStorage(Storage):
 packageStorage = __PackageStorage()
 
 class PackageManager(object):
-    DOWNLOAD_DIR=os.environ.get("PIXIEDUST_HOME", os.path.expanduser('~')) + "/data/libs"
+    if "PIXIEDUST_HOME" in os.environ:
+        DOWNLOAD_DIR=os.environ.get("PIXIEDUST_HOME") + "/data/libs"
+    elif "PIXIEDUST_LIBS_PATH" in os.environ:
+        DOWNLOAD_DIR=os.environ.get("PIXIEDUST_LIBS_PATH")
+    else:
+        DOWNLOAD_DIR=os.environ.get("HOME") + "/data/libs"
+
 
     # Issue 492: https://github.com/ibm-watson-data-lab/pixiedust/issues/492
     # Make sure that DOWNLOAD_DIR is in the java classpath


### PR DESCRIPTION
if `PIXIEDUST_HOME` is defined then use `PIXIEDUST_HOME + data/libs` (this would be for local install, etc) else if `PIXIEDUST_LIBS_PATH` is defined use it as is else default to `~/data/libs`.
Issues:
https://github.com/pixiedust/pixiedust/issues/492
https://github.com/pixiedust/pixiedust/issues/730