### PR TITLE
issue-735 fix for pixiedust jar

### DIFF
--- a/pixiedust/utils/__init__.py
+++ b/pixiedust/utils/__init__.py
@@ -28,8 +28,14 @@ def fqName(entity):
     return (entity.__module__ + "." if hasattr(entity, "__module__") else "") + entity.__class__.__name__
 
 #init scala bridge, make sure that correct pixiedust.jar is installed
+# Issue 735: https://github.com/pixiedust/pixiedust/issues/735
+if "PIXIEDUST_HOME" in os.environ:
+    jarDirPath=os.environ.get('PIXIEDUST_HOME') + "/data/libs/"
+elif "PIXIEDUST_LIBS_PATH" in os.environ:
+    jarDirPath=os.environ.get('PIXIEDUST_LIBS_PATH')
+else:
+    jarDirPath=os.environ.get('HOME') + "/data/libs/"
 
-jarDirPath = os.environ.get("PIXIEDUST_HOME", os.path.expanduser('~')) + "/data/libs/"
 jarFilePath = jarDirPath + "pixiedust.jar"
 
 dir = os.path.dirname(jarDirPath)


### PR DESCRIPTION
tested : 
**!pip install --upgrade git+https://github.com/shobhit0511/pixiedust.git@issue-735-pixiedust-jar#egg=pixiedust**

> Collecting pixiedust from git+https://github.com/shobhit0511/pixiedust.git@issue-735-pixiedust-jar#egg=pixiedust
>   Cloning https://github.com/shobhit0511/pixiedust.git (to revision issue-735-pixiedust-jar) to /tmp/pip-install-gW3Alq/pixiedust
> Collecting mpld3 (from pixiedust)
>   Downloading https://files.pythonhosted.org/packages/91/95/a52d3a83d0a29ba0d6898f6727e9858fe7a43f6c2ce81a5fe7e05f0f4912/mpld3-0.3.tar.gz (788kB)
>     100% |################################| 798kB 3.0MB/s eta 0:00:01
> Collecting lxml (from pixiedust)
>   Downloading https://files.pythonhosted.org/packages/e5/14/f4343239f955442da9da1919a99f7311bc5627522741bada61b2349c8def/lxml-4.2.5-cp27-cp27mu-manylinux1_x86_64.whl (5.8MB)
>     100% |################################| 5.8MB 1.0MB/s eta 0:00:01
> Collecting geojson (from pixiedust)
>   Downloading https://files.pythonhosted.org/packages/8d/39/231105abbfd2332f108cdbfe736e56324949fa9e80e536ae60a082cf96a9/geojson-2.4.0-py2.py3-none-any.whl
> Collecting astunparse (from pixiedust)
>   Downloading https://files.pythonhosted.org/packages/0d/9d/1576217f67e7420f5945c15c6afd7045178c4850b148741bdbdbdabbf40e/astunparse-1.6.1-py2.py3-none-any.whl
> Collecting markdown (from pixiedust)
>   Downloading https://files.pythonhosted.org/packages/7a/6b/5600647404ba15545ec37d2f7f58844d690baf2f81f3a60b862e48f29287/Markdown-3.0.1-py2.py3-none-any.whl (89kB)
>     100% |################################| 92kB 3.9MB/s eta 0:00:01
> Collecting colour (from pixiedust)
>   Downloading https://files.pythonhosted.org/packages/74/46/e81907704ab203206769dee1385dc77e1407576ff8f50a0681d0a6b541be/colour-0.1.5-py2.py3-none-any.whl
> Collecting requests (from pixiedust)
>   Downloading https://files.pythonhosted.org/packages/65/47/7e02164a2a3db50ed6d8a6ab1d6d60b69c4c3fdf57a284257925dfc12bda/requests-2.19.1-py2.py3-none-any.whl (91kB)
>     100% |################################| 92kB 3.8MB/s eta 0:00:01
> Collecting wheel<1.0,>=0.23.0 (from astunparse->pixiedust)
>   Downloading https://files.pythonhosted.org/packages/fc/e9/05316a1eec70c2bfc1c823a259546475bd7636ba6d27ec80575da523bc34/wheel-0.32.1-py2.py3-none-any.whl
> Collecting six<2.0,>=1.6.1 (from astunparse->pixiedust)
>   Downloading https://files.pythonhosted.org/packages/67/4b/141a581104b1f6397bfa78ac9d43d8ad29a7ca43ea90a2d863fe3056e86a/six-1.11.0-py2.py3-none-any.whl
> Collecting idna<2.8,>=2.5 (from requests->pixiedust)
>   Downloading https://files.pythonhosted.org/packages/4b/2a/0276479a4b3caeb8a8c1af2f8e4355746a97fab05a372e4a2c6a6b876165/idna-2.7-py2.py3-none-any.whl (58kB)
>     100% |################################| 61kB 2.3MB/s eta 0:00:01
> Collecting chardet<3.1.0,>=3.0.2 (from requests->pixiedust)
>   Downloading https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl (133kB)
>     100% |################################| 143kB 4.1MB/s eta 0:00:01
> Collecting urllib3<1.24,>=1.21.1 (from requests->pixiedust)
>   Downloading https://files.pythonhosted.org/packages/bd/c9/6fdd990019071a4a32a5e7cb78a1d92c53851ef4f56f62a3486e6a7d8ffb/urllib3-1.23-py2.py3-none-any.whl (133kB)
>     100% |################################| 143kB 3.9MB/s eta 0:00:01
> Collecting certifi>=2017.4.17 (from requests->pixiedust)
>   Downloading https://files.pythonhosted.org/packages/df/f7/04fee6ac349e915b82171f8e23cee63644d83663b34c539f7a09aed18f9e/certifi-2018.8.24-py2.py3-none-any.whl (147kB)
>     100% |################################| 153kB 3.9MB/s eta 0:00:01
> Building wheels for collected packages: pixiedust, mpld3
>   Running setup.py bdist_wheel for pixiedust ... done
>   Stored in directory: /tmp/pip-ephem-wheel-cache-Xqd8J1/wheels/f8/8f/b5/a6bcf2af675500c1bdf6a4e9df597b2f01cbc1a9d35be1e65a
>   Running setup.py bdist_wheel for mpld3 ... done
>   Stored in directory: /home/spark/shared/.cache/pip/wheels/c0/47/fb/8a64f89aecfe0059830479308ad42d62e898a3e3cefdf6ba28
> Successfully built pixiedust mpld3
> tensorflow 1.3.0 requires tensorflow-tensorboard<0.2.0,>=0.1.0, which is not installed.
> pyspark 2.3.0 requires py4j==0.10.6, which is not installed.
> Installing collected packages: mpld3, lxml, geojson, wheel, six, astunparse, markdown, colour, idna, chardet, urllib3, certifi, requests, pixiedust
> Successfully installed astunparse-1.6.1 certifi-2018.8.24 chardet-3.0.4 colour-0.1.5 geojson-2.4.0 idna-2.7 lxml-4.2.5 markdown-3.0.1 mpld3-0.3 pixiedust-1.1.12 requests-2.19.1 six-1.11.0 urllib3-1.23 wheel-0.32.1

<img width="1239" alt="screen shot 2018-10-07 at 2 18 06 pm" src="https://user-images.githubusercontent.com/10229426/46580096-daf26500-ca3b-11e8-9c37-789ef4901bca.png">
<img width="1178" alt="screen shot 2018-10-07 at 2 18 39 pm" src="https://user-images.githubusercontent.com/10229426/46580100-ee053500-ca3b-11e8-9c92-f794a0dc6452.png">
