### PR TITLE
FIX pixiedust install fails on installing Spark 2.3 (update broken Sp…

### DIFF
--- a/install/createKernel.py
+++ b/install/createKernel.py
@@ -37,13 +37,13 @@ class PixiedustInstall(InstallKernelSpec):
         super(PixiedustInstall, self).__init__(**kwargs)
         self.pixiedust_home = None
         self.spark_home = None
-        self.spark_download_versions = ['1.6.3', '2.0.2', '2.1.0', '2.2.0', '2.3.0']
+        self.spark_download_versions = ['1.6.3', '2.0.2', '2.1.0', '2.2.0', '2.3.2']
         self.spark_download_urls = {
             '1.6.3': 'http://d3kbcqa49mib13.cloudfront.net/spark-1.6.3-bin-hadoop2.6.tgz',
             '2.0.2': 'http://d3kbcqa49mib13.cloudfront.net/spark-2.0.2-bin-hadoop2.7.tgz',
             '2.1.0': 'http://d3kbcqa49mib13.cloudfront.net/spark-2.1.0-bin-hadoop2.7.tgz',
             '2.2.0': 'https://d3kbcqa49mib13.cloudfront.net/spark-2.2.0-bin-hadoop2.7.tgz',
-            '2.3.0': 'http://apache.claz.org/spark/spark-2.3.0/spark-2.3.0-bin-hadoop2.7.tgz'
+            '2.3.2': 'http://apache.claz.org/spark/spark-2.3.2/spark-2.3.2-bin-hadoop2.7.tgz'
         }
         self.scala_home = None
         self.scala_download_urls = {


### PR DESCRIPTION
…ark download URL to 2.3.2)

Fixes issue: https://github.com/pixiedust/pixiedust/issues/714

And other duplicate issues:
https://github.com/pixiedust/pixiedust/issues/741
https://github.com/pixiedust/pixiedust/issues/738
 
The Spark download URL for version 2.3.0 is broken. Updated to the working 2.3.2 version.

Test with:

> jupyter pixiedust install